### PR TITLE
Fix same row drag drop id parsing for ambiguous card id <number | string> Card id now has id as string instead of number, ensuring consistency in ID handling across the dynamic board context and provider.

### DIFF
--- a/src/core/context/dynamic-board-context.ts
+++ b/src/core/context/dynamic-board-context.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 
-export type DynamicBoardCardId = number | string;
-export type DynamicBoardRowId = number | string;
+export type DynamicBoardCardId = string;
+export type DynamicBoardRowId = string;
 
 export interface DynamicBoardCardLayout {
   row: number;

--- a/src/core/context/dynamic-board-provider.tsx
+++ b/src/core/context/dynamic-board-provider.tsx
@@ -727,7 +727,7 @@ export function DynamicBoardProvider<Content = unknown>({
             const [targetCardRecord, targetRowRecord] =
               location.current.dropTargets;
             const targetRowId = targetRowRecord.data.id as string;
-            const targetCardId = parseInt(targetCardRecord.data.id as string);
+            const targetCardId = targetCardRecord.data.id as string;
             const targetRow = findRow(targetRowId);
             if (!targetRow) return;
 


### PR DESCRIPTION
Fix same row drag drop id parsing for ambiguous card id <number | string> Card id now has id as string instead of number, ensuring consistency in ID handling across the dynamic board context and provider.