### PR TITLE
Add GitHub username constant and update ExampleBoard to use it

### DIFF
--- a/src/example/data/githubUsername.ts
+++ b/src/example/data/githubUsername.ts
@@ -1,0 +1,1 @@
+export const GITHUB_USERNAME = "BUMBAIYA";

--- a/src/example/example-board.tsx
+++ b/src/example/example-board.tsx
@@ -15,6 +15,7 @@ import { useDynamicBoard } from "@/core/hooks/useDynamicBoard";
 
 import { ExampleCardImplementation } from "@/example/example-card-implementation";
 import { AddNewCard } from "@/example/components/add-new-card";
+import { GITHUB_USERNAME } from "@/example/data/githubUsername";
 import type { MockCardContent } from "@/example/types";
 
 export function ExampleBoard() {
@@ -51,7 +52,7 @@ export function ExampleBoard() {
                             <ExampleCardImplementation
                               key={card.id}
                               {...cardProps}
-                              githubUsername={"bumbaiya"}
+                              githubUsername={GITHUB_USERNAME}
                             />
                           )}
                         </DynamicBoardCard>


### PR DESCRIPTION
- Introduced a new constant `GITHUB_USERNAME` in `githubUsername.ts` for better maintainability.
- Updated `ExampleBoard` to utilize the `GITHUB_USERNAME` constant instead of hardcoding the username.