### PR TITLE
Refactor ExampleBoardWrapper and introduce AppHeader component

### DIFF
--- a/src/example/components/app-header.tsx
+++ b/src/example/components/app-header.tsx
@@ -1,0 +1,17 @@
+import { ProjectInfoButton } from "@/example/components/project-info-button";
+import { GithubAnchor } from "@/example/components/github-anchor";
+import { useExampleBoard } from "@/example/context/useExampleBoard";
+
+export function AppHeader() {
+  const { setShowProjectInfoModal } = useExampleBoard();
+
+  return (
+    <div className="sticky top-0 z-50 flex min-h-10 items-center justify-between border-b border-gray-200 bg-white px-4">
+      <h1 className="font-medium">Dynamic Boards</h1>
+      <div className="flex items-center space-x-2">
+        <ProjectInfoButton onClick={() => setShowProjectInfoModal(true)} />
+        <GithubAnchor />
+      </div>
+    </div>
+  );
+}

--- a/src/example/context/example-board-context.ts
+++ b/src/example/context/example-board-context.ts
@@ -36,6 +36,8 @@ export interface ExampleBoardContextType {
    * @param modalData.data.customCardData - The customCardData for the modal. Only need when editing a card.
    */
   setShowOpenEditModal: (modalData: AddEditCardModalState) => void;
+  showProjectInfoModal: boolean;
+  setShowProjectInfoModal: (show: boolean) => void;
 }
 
 export const ExampleBoardContext =

--- a/src/example/context/example-board-provider.tsx
+++ b/src/example/context/example-board-provider.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/example/context/example-board-context";
 import { useDynamicBoard } from "@/core/hooks/useDynamicBoard";
 import { AddEditCard } from "@/example/components/add-edit-card";
+import { ProjectInfoModal } from "@/example/components/project-info-modal";
 import type { MockCardContent } from "@/example/types";
 
 export interface ExampleBoardProviderProps {
@@ -14,6 +15,7 @@ export interface ExampleBoardProviderProps {
 
 export function ExampleBoardProvider({ children }: ExampleBoardProviderProps) {
   const { addCard, updateCard } = useDynamicBoard<MockCardContent>();
+  const [showProjectInfoModal, setShowProjectInfoModal] = useState(true);
   const [showOpenEditModal, setShowOpenEditModal] = useState<
     ExampleBoardContextType["showOpenEditModal"]
   >({
@@ -23,7 +25,12 @@ export function ExampleBoardProvider({ children }: ExampleBoardProviderProps) {
 
   return (
     <ExampleBoardContext.Provider
-      value={{ showOpenEditModal, setShowOpenEditModal }}
+      value={{
+        showOpenEditModal,
+        setShowOpenEditModal,
+        showProjectInfoModal,
+        setShowProjectInfoModal,
+      }}
     >
       {children}
       <AddEditCard
@@ -57,6 +64,12 @@ export function ExampleBoardProvider({ children }: ExampleBoardProviderProps) {
             data: null,
           });
         }}
+      />
+      {/* This is the example project info modal. */}
+      <ProjectInfoModal
+        open={showProjectInfoModal}
+        onChange={setShowProjectInfoModal}
+        closeOnClickOutside={false}
       />
     </ExampleBoardContext.Provider>
   );

--- a/src/example/example-board-wrapper.tsx
+++ b/src/example/example-board-wrapper.tsx
@@ -1,50 +1,25 @@
-import { useState } from "react";
-
 import { DynamicBoardProvider } from "@/core/context/dynamic-board-provider";
 import { ExampleBoard } from "@/example/example-board";
-import { GithubAnchor } from "@/example/components/github-anchor";
-import { ProjectInfoButton } from "@/example/components/project-info-button";
 import { MOCK_CARD_DATA } from "@/example/data/mockCardData";
 import { ExampleBoardProvider } from "@/example/context/example-board-provider";
-import { ProjectInfoModal } from "@/example/components/project-info-modal";
+import { AppHeader } from "@/example/components/app-header";
 
 export function ExampleBoardWrapper() {
-  const [showProjectInfoModal, setShowProjectInfoModal] = useState(true);
-
   return (
-    <>
-      <DynamicBoardProvider
-        initialCards={MOCK_CARD_DATA}
-        boardConfig={{
-          maxCardsPerRow: 3,
-          enableLayoutCorrection: true,
-          disableCardDropInBetweenRows: true,
-          maxHeight: 700,
-        }}
-      >
+    <DynamicBoardProvider
+      initialCards={MOCK_CARD_DATA}
+      boardConfig={{
+        maxCardsPerRow: 3,
+        enableLayoutCorrection: true,
+        maxHeight: 700,
+      }}
+    >
+      <ExampleBoardProvider>
         <div className="flex min-h-screen w-full flex-col">
-          <div className="sticky top-0 z-50 flex min-h-10 items-center justify-between border-b border-gray-200 bg-white px-4">
-            <h1 className="font-medium">Dynamic Boards</h1>
-            <div className="flex items-center space-x-2">
-              <ProjectInfoButton
-                onClick={() => setShowProjectInfoModal(true)}
-              />
-              <GithubAnchor />
-            </div>
-          </div>
-          {/* This is the example board provider. */}
-          {/* User need to implement their own provider here according to their own needs/business logic. */}
-          <ExampleBoardProvider>
-            <ExampleBoard />
-          </ExampleBoardProvider>
+          <AppHeader />
+          <ExampleBoard />
         </div>
-      </DynamicBoardProvider>
-      {/* This is the example project info modal. */}
-      <ProjectInfoModal
-        open={showProjectInfoModal}
-        onChange={setShowProjectInfoModal}
-        closeOnClickOutside={false}
-      />
-    </>
+      </ExampleBoardProvider>
+    </DynamicBoardProvider>
   );
 }

--- a/src/example/example-card-implementation.tsx
+++ b/src/example/example-card-implementation.tsx
@@ -10,7 +10,7 @@ import {
   GitHubMetricsCard,
   GitHubFollowersCard,
 } from "@/example/components/github-cards";
-import { GITHUB_CARD_TYPE_TO_ICON_MAPPING } from "./card-type-to-icon-mapping";
+import { GITHUB_CARD_TYPE_TO_ICON_MAPPING } from "@/example/card-type-to-icon-mapping";
 
 export type CardImplementationProps =
   DynamicBoardCardChildrenProps<MockCardContent> & {


### PR DESCRIPTION
- Removed the ProjectInfoModal and related state management from ExampleBoardWrapper.
- Created a new AppHeader component to encapsulate the header functionality, including ProjectInfoButton and GithubAnchor.
- Updated ExampleBoardProvider to manage the visibility of ProjectInfoModal and added necessary context methods.